### PR TITLE
inject hafasClient lazily into the service

### DIFF
--- a/backend/src/hafas/hafasClient.ts
+++ b/backend/src/hafas/hafasClient.ts
@@ -1,0 +1,14 @@
+import { HafasClient } from "hafas-client";
+
+/**
+ * Import of hafas-client (workaround to use ESM inside CommonJS project).
+ */
+export async function importHafasClient(): Promise<HafasClient> {
+    const { createClient } = await (
+        eval("import(\"hafas-client\")") as Promise<typeof import("hafas-client")>);
+    const { profile } = await (
+        eval("import(\"hafas-client/p/db/index.js\")") as Promise<typeof import("hafas-client/p/db/index.js")>);
+
+    const userAgent = "oeffis";
+    return createClient(profile, userAgent);
+}

--- a/backend/src/journey/journey.module.ts
+++ b/backend/src/journey/journey.module.ts
@@ -1,10 +1,33 @@
-import {Module} from "@nestjs/common";
-import {JourneyController} from "./journey.controller";
-import {JourneyService} from "./journey.service";
+import { Module } from "@nestjs/common";
+import { HafasClient } from "hafas-client";
+import { HAFAS_CLIENT } from "src/symbols";
+import { JourneyController } from "./journey.controller";
+import { JourneyService } from "./journey.service";
+
+/**
+ * Import of hafas-client (workaround to use ESM inside CommonJS project).
+ */
+const hafasClientImport: Promise<HafasClient> =
+  (async (): Promise<HafasClient> => {
+    const { createClient } = await (
+      eval("import(\"hafas-client\")") as Promise<typeof import("hafas-client")>);
+    const { profile } = await (
+      eval("import(\"hafas-client/p/db/index.js\")") as Promise<typeof import("hafas-client/p/db/index.js")>);
+
+    const userAgent = "oeffis";
+    return createClient(profile, userAgent);
+  })();
+
 
 @Module({
   controllers: [JourneyController],
-  providers: [JourneyService],
+  providers: [
+    JourneyService,
+    {
+      provide: HAFAS_CLIENT,
+      useFactory: async (): Promise<HafasClient> => hafasClientImport
+    }
+  ],
 })
 
 export class JourneyModule { }

--- a/backend/src/journey/journey.module.ts
+++ b/backend/src/journey/journey.module.ts
@@ -1,23 +1,8 @@
 import { Module } from "@nestjs/common";
-import { HafasClient } from "hafas-client";
-import { HAFAS_CLIENT } from "src/symbols";
+import { importHafasClient } from "hafas/hafasClient";
+import { HAFAS_CLIENT } from "../symbols";
 import { JourneyController } from "./journey.controller";
 import { JourneyService } from "./journey.service";
-
-/**
- * Import of hafas-client (workaround to use ESM inside CommonJS project).
- */
-const hafasClientImport: Promise<HafasClient> =
-  (async (): Promise<HafasClient> => {
-    const { createClient } = await (
-      eval("import(\"hafas-client\")") as Promise<typeof import("hafas-client")>);
-    const { profile } = await (
-      eval("import(\"hafas-client/p/db/index.js\")") as Promise<typeof import("hafas-client/p/db/index.js")>);
-
-    const userAgent = "oeffis";
-    return createClient(profile, userAgent);
-  })();
-
 
 @Module({
   controllers: [JourneyController],
@@ -25,7 +10,7 @@ const hafasClientImport: Promise<HafasClient> =
     JourneyService,
     {
       provide: HAFAS_CLIENT,
-      useFactory: async (): Promise<HafasClient> => hafasClientImport
+      useFactory: importHafasClient
     }
   ],
 })

--- a/backend/src/journey/journey.service.spec.ts
+++ b/backend/src/journey/journey.service.spec.ts
@@ -1,23 +1,29 @@
-import {Test, TestingModule} from "@nestjs/testing";
-import {JourneyService} from "./journey.service";
+import { Test, TestingModule } from "@nestjs/testing";
+import { HAFAS_CLIENT } from "../symbols";
+import { JourneyService } from "./journey.service";
 
 describe("JourneyService", () => {
   let service: JourneyService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [JourneyService],
+      providers: [
+        JourneyService,
+        {
+          provide: HAFAS_CLIENT,
+          useValue: {
+            locations: jest.fn().mockResolvedValue([{ name: "Gelsenkirchen Hbf" }]),
+          }
+        }
+      ],
     }).compile();
 
     service = module.get<JourneyService>(JourneyService);
   });
 
-  it("should return query results", () => {
+  it("should return query results", async () => {
     const locationQuery = "Wuppertal";
 
-    expect(service.searchLocations(locationQuery))
-      .toBeDefined(); // TODO Wie hier vernünftig asserten?
+    expect(await service.searchLocations(locationQuery)).toContainEqual({ name: "Gelsenkirchen Hbf" });
   });
-
-
 });

--- a/backend/src/journey/journey.service.ts
+++ b/backend/src/journey/journey.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { HafasClient, Journeys, Location, Station, Stop } from "hafas-client";
-import { HAFAS_CLIENT } from "src/symbols";
+import { HAFAS_CLIENT } from "../symbols";
 import { JourneyRequest } from "./entities/journey.request.entity";
 
 

--- a/backend/src/journey/journey.service.ts
+++ b/backend/src/journey/journey.service.ts
@@ -1,54 +1,25 @@
-import {Injectable} from "@nestjs/common";
-import {HafasClient, Journeys, Location, Station, Stop} from "hafas-client";
-import {JourneyRequest} from "./entities/journey.request.entity";
+import { Inject, Injectable } from "@nestjs/common";
+import { HafasClient, Journeys, Location, Station, Stop } from "hafas-client";
+import { HAFAS_CLIENT } from "src/symbols";
+import { JourneyRequest } from "./entities/journey.request.entity";
 
-const userAgent = "oeffis"; // TODO What string to use?
-
-/**
- * Import of hafas-client (workaround to use ESM inside CommonJS project).
- */
-const hafasClientImport: Promise<HafasClient> =
-  (async (): Promise<HafasClient> => {
-    const {createClient} = await (
-      eval("import(\"hafas-client\")") as Promise<typeof import("hafas-client")>);
-    const {profile} = await (
-      eval("import(\"hafas-client/p/db/index.js\")") as Promise<typeof import("hafas-client/p/db/index.js")>);
-
-    return createClient(profile, userAgent);
-  })();
 
 /**
  * Service that uses HAFAS to plan a journey.
  */
 @Injectable()
 export class JourneyService {
-
-  private hafas: HafasClient;
-
-  constructor() {
-    // TODO überall den then-Kontext verwenden oder kann man das hier vernünftig vorher machen?
-    hafasClientImport
-      .then(value => this.hafas = value)
-      .catch(reason => console.log(reason));  // TODO How to handle error?
-  }
+  constructor(
+    @Inject(HAFAS_CLIENT) private hafas: HafasClient
+  ) { }
 
   searchLocations(locationQuery: string): Promise<ReadonlyArray<Station | Stop | Location>> {
-    return hafasClientImport
-      .then(hafasClient => hafasClient.locations(
-        locationQuery,
-        {
-          results: null, // Get everything returned by HAFAS.
-          language: "de", // TODO using DE testwise.
-        }
-      ));
-
-    // return this.hafas.locations(
-    //   locationRequest.locationQuery,
-    //   {
-    //     results: null, // Get everything returned by HAFAS.
-    //     language: "de", // TODO using DE testwise.
-    //   }
-    // );
+    return this.hafas.locations(
+      locationQuery,
+      {
+        language: "de",
+      }
+    );
   }
 
   /**
@@ -58,21 +29,12 @@ export class JourneyService {
    * @return all possible plans for the journey
    */
   planJourney(journeyRequest: JourneyRequest): Promise<Journeys> {
-    return hafasClientImport
-      .then(hafasClient => hafasClient.journeys(
-        journeyRequest.from, journeyRequest.to,
-        {
-          results: 3, // Get everything returned by HAFAS.
-          language: "de", // TODO using DE testwise.
-        }
-      ));
-
-    // return this.hafas.journeys(
-    //   journeyRequest.from, journeyRequest.to,
-    //   {
-    //     results: null, // Get everything returned by HAFAS.
-    //     language: "de", // TODO using DE testwise.
-    //   });
+    return this.hafas.journeys(
+      journeyRequest.from, journeyRequest.to,
+      {
+        results: 3,
+        language: "de",
+      }
+    );
   }
-
 }

--- a/backend/src/symbols.ts
+++ b/backend/src/symbols.ts
@@ -1,0 +1,1 @@
+export const HAFAS_CLIENT = Symbol("HAFAS_CLIENT");

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,13 +9,13 @@
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": "./src",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
   }
 }


### PR DESCRIPTION
### Description

I took a look at the ESM import problem. You seem to be right, there doesn't seem like a good solution at the current point of time. However, I would like to propose to include these changes, as it removes the lazily import from the service. I extracted it to the module and now inject the client using an asynchronous factory.

## Checklist

- [x] My code follows the style guidelines
- [x] I have documented my code
- [x] My changes generate no new warnings
- [x] I have linked the Issue
- [x] The Pull Request covers all the Checkpoints from the tagged Issue
- [x] I have noted the hours of work i have put in the issue

## I have edited following Parts of the project

- [ ] Frontend
- [x] Backend
- [ ] Github
- [ ] Root

## If tests are required did you make them?

- [x] No tests required
- [ ] Yes
- [ ] No
