### PR TITLE
Fix/302 openapi windows mounting

### DIFF
--- a/update_frontend_api_client.sh
+++ b/update_frontend_api_client.sh
@@ -29,5 +29,5 @@ docker run --rm -v //"$PWD":/work openapitools/openapi-generator-cli:v7.0.0 \
   --config //work/frontend/api_client_generator_settings.json \
   --output //work/frontend/src/api/
 
-cp -a frontend/src/api/src/ frontend/src/api/
+cp -a frontend/src/api/src/** frontend/src/api/
 rm -fr frontend/src/api/src/

--- a/update_frontend_api_client.sh
+++ b/update_frontend_api_client.sh
@@ -22,12 +22,12 @@ tsconfig.esm.json
 
 echo "Generating code from swagger spec"
 
-docker run --rm -v $PWD:/work openapitools/openapi-generator-cli:v7.0.0 \
+docker run --rm -v //"$PWD":/work openapitools/openapi-generator-cli:v7.0.0 \
   generate \
-  --input-spec /work/backend/swagger-spec.json \
+  --input-spec //work/backend/swagger-spec.json \
   --generator-name typescript-fetch \
-  --config /work/frontend/api_client_generator_settings.json \
-  --output /work/frontend/src/api/
+  --config //work/frontend/api_client_generator_settings.json \
+  --output //work/frontend/src/api/
 
 cp -a frontend/src/api/src/ frontend/src/api/
 rm -fr frontend/src/api/src/

--- a/update_frontend_api_client.sh
+++ b/update_frontend_api_client.sh
@@ -22,6 +22,8 @@ tsconfig.esm.json
 
 echo "Generating code from swagger spec"
 
+# Use double slash as path prefix because Git Bash on Windows is doing some wrong auto-conversion otherwise
+# (leading to paths being resolved wrong - relative to Git (Bash) installation directory).
 docker run --rm -v //"$PWD":/work openapitools/openapi-generator-cli:v7.0.0 \
   generate \
   --input-spec //work/backend/swagger-spec.json \


### PR DESCRIPTION
### Description

Fixes problems with paths for openapi-generator are being resolved wrong on Windows platform using Git Bash. Solves #302 .

## Checklist

- [x] My code follows the style guidelines
- [x] I have documented my code
- [x] My changes generate no new warnings
- [x] I have linked the Issue
- [x] The Pull Request covers all the Checkpoints from the tagged Issue
- [x] I have noted the hours of work i have put in the issue

## I have edited following Parts of the project

- [ ] Frontend
- [ ] Backend
- [ ] Github
- [x] Root

## If tests are required did you make them?

- [x] No tests required
- [ ] Yes
- [ ] No
